### PR TITLE
chore: Prepare v2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.2.0 - 2024-04-29
+### Changed
+* Update NPM version to LTS v10
+* Migrate to Vite for building and Vitest for testing
+* Lint files using ESLint (+ add CI workflow) and move to all Typescript
+* Add tests and code coverage badge to README
+
 ## 2.1.0 - 2023-07-23
 ### Fixed
 - Set explicit file extensions for package entry files to allow usage with `module` packages \([\#513](https://github.com/nextcloud/nextcloud-initial-state/pull/513)\)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/initial-state",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/initial-state",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@nextcloud/eslint-config": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/initial-state",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Access data from the nextcloud server-side initial state API within apps.",
   "homepage": "https://github.com/nextcloud/nextcloud-initial-state#readme",
   "author": "Christoph Wurst",


### PR DESCRIPTION
## 2.2.0 - 2024-04-29
### Changed
* Update NPM version to LTS v10
* Migrate to Vite for building and Vitest for testing
* Lint files using ESLint (+ add CI workflow) and move to all Typescript
* Add tests and code coverage badge to README